### PR TITLE
DEVOPS-579 Add existing IAM Role support.

### DIFF
--- a/logging.tf
+++ b/logging.tf
@@ -1,7 +1,7 @@
 resource "aws_iam_role_policy" "instance" {
   count  = var.enable_cloudwatch_logging ? 1 : 0
   name   = "${local.name_iam_objects}-instance-role"
-  role   = aws_iam_role.instance.name
+  role   = var.runner_iam_role_name == ""  ? aws_iam_role.instance[0].name : var.runner_iam_role_name
   policy = templatefile("${path.module}/policies/instance-logging-policy.json", { arn_format = var.arn_format })
 }
 

--- a/main.tf
+++ b/main.tf
@@ -326,11 +326,12 @@ module "cache" {
 ################################################################################
 resource "aws_iam_instance_profile" "instance" {
   name = "${local.name_iam_objects}-instance"
-  role = aws_iam_role.instance.name
+  role = var.runner_iam_role_name == ""  ? aws_iam_role.instance[0].name : var.runner_iam_role_name
   tags = local.tags
 }
 
 resource "aws_iam_role" "instance" {
+  count = var.runner_iam_role_name == ""  ? 0 : 1
   name                 = "${local.name_iam_objects}-instance"
   assume_role_policy   = length(var.instance_role_json) > 0 ? var.instance_role_json : templatefile("${path.module}/policies/instance-role-trust-policy.json", {})
   permissions_boundary = var.permissions_boundary == "" ? null : "${var.arn_format}:iam::${data.aws_caller_identity.current.account_id}:policy/${var.permissions_boundary}"
@@ -348,13 +349,13 @@ resource "aws_iam_policy" "instance_docker_machine_policy" {
   description = "Policy for docker machine."
   policy = templatefile("${path.module}/policies/instance-docker-machine-policy.json",
     {
-      docker_machine_role_arn = aws_iam_role.docker_machine.arn
+      docker_machine_role_arn =  var.docker_machine_iam_role_name == ""  ? aws_iam_role.docker_machine[0].name : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.docker_machine_iam_role_name}"
   })
   tags = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "instance_docker_machine_policy" {
-  role       = aws_iam_role.instance.name
+  role       = var.runner_iam_role_name == ""  ? aws_iam_role.instance[0].name : var.runner_iam_role_name
   policy_arn = aws_iam_policy.instance_docker_machine_policy.arn
 }
 
@@ -374,14 +375,14 @@ resource "aws_iam_policy" "instance_session_manager_policy" {
 resource "aws_iam_role_policy_attachment" "instance_session_manager_policy" {
   count = var.enable_runner_ssm_access ? 1 : 0
 
-  role       = aws_iam_role.instance.name
+  role       = var.runner_iam_role_name == ""  ? aws_iam_role.instance[0].name : var.runner_iam_role_name
   policy_arn = aws_iam_policy.instance_session_manager_policy[0].arn
 }
 
 resource "aws_iam_role_policy_attachment" "instance_session_manager_aws_managed" {
   count = var.enable_runner_ssm_access ? 1 : 0
 
-  role       = aws_iam_role.instance.name
+  role       = var.runner_iam_role_name == ""  ? aws_iam_role.instance[0].name : var.runner_iam_role_name
   policy_arn = "${var.arn_format}:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
 
@@ -390,7 +391,7 @@ resource "aws_iam_role_policy_attachment" "instance_session_manager_aws_managed"
 ################################################################################
 resource "aws_iam_role_policy_attachment" "user_defined_policies" {
   count      = length(var.runner_iam_policy_arns)
-  role       = aws_iam_role.instance.name
+  role       = var.runner_iam_role_name == ""  ? aws_iam_role.instance[0].name : var.runner_iam_role_name
   policy_arn = var.runner_iam_policy_arns[count.index]
 }
 
@@ -399,7 +400,7 @@ resource "aws_iam_role_policy_attachment" "user_defined_policies" {
 ################################################################################
 resource "aws_iam_role_policy_attachment" "docker_machine_cache_instance" {
   count      = var.cache_bucket["create"] || lookup(var.cache_bucket, "policy", "") != "" ? 1 : 0
-  role       = aws_iam_role.instance.name
+  role       = var.runner_iam_role_name == ""  ? aws_iam_role.instance[0].name : var.runner_iam_role_name
   policy_arn = local.bucket_policy
 }
 
@@ -407,6 +408,7 @@ resource "aws_iam_role_policy_attachment" "docker_machine_cache_instance" {
 ### docker machine instance policy
 ################################################################################
 resource "aws_iam_role" "docker_machine" {
+  count = var.docker_machine_iam_role_name == ""  ? 0 : 1
   name                 = "${local.name_iam_objects}-docker-machine"
   assume_role_policy   = length(var.docker_machine_role_json) > 0 ? var.docker_machine_role_json : templatefile("${path.module}/policies/instance-role-trust-policy.json", {})
   permissions_boundary = var.permissions_boundary == "" ? null : "${var.arn_format}:iam::${data.aws_caller_identity.current.account_id}:policy/${var.permissions_boundary}"
@@ -415,7 +417,7 @@ resource "aws_iam_role" "docker_machine" {
 
 resource "aws_iam_instance_profile" "docker_machine" {
   name = "${local.name_iam_objects}-docker-machine"
-  role = aws_iam_role.docker_machine.name
+  role = var.docker_machine_iam_role_name == ""  ? aws_iam_role.docker_machine[0].name : var.docker_machine_iam_role_name
   tags = local.tags
 }
 
@@ -424,7 +426,7 @@ resource "aws_iam_instance_profile" "docker_machine" {
 ################################################################################
 resource "aws_iam_role_policy_attachment" "docker_machine_user_defined_policies" {
   count      = length(var.docker_machine_iam_policy_arns)
-  role       = aws_iam_role.docker_machine.name
+  role       =  var.docker_machine_iam_role_name == ""  ? aws_iam_role.docker_machine[0].name : var.docker_machine_iam_role_name
   policy_arn = var.docker_machine_iam_policy_arns[count.index]
 }
 
@@ -432,7 +434,7 @@ resource "aws_iam_role_policy_attachment" "docker_machine_user_defined_policies"
 resource "aws_iam_role_policy_attachment" "docker_machine_session_manager_aws_managed" {
   count = var.enable_docker_machine_ssm_access ? 1 : 0
 
-  role       = aws_iam_role.docker_machine.name
+  role       = aws_iam_role.docker_machine[0].name
   policy_arn = "${var.arn_format}:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
 
@@ -452,7 +454,7 @@ resource "aws_iam_policy" "service_linked_role" {
 resource "aws_iam_role_policy_attachment" "service_linked_role" {
   count = var.allow_iam_service_linked_role_creation ? 1 : 0
 
-  role       = aws_iam_role.instance.name
+  role       = var.runner_iam_role_name == ""  ? aws_iam_role.instance[0].name : var.runner_iam_role_name
   policy_arn = aws_iam_policy.service_linked_role[0].arn
 }
 
@@ -476,7 +478,7 @@ resource "aws_iam_policy" "ssm" {
 resource "aws_iam_role_policy_attachment" "ssm" {
   count = var.enable_manage_gitlab_token ? 1 : 0
 
-  role       = aws_iam_role.instance.name
+  role       = var.runner_iam_role_name == ""  ? aws_iam_role.instance[0].name : var.runner_iam_role_name
   policy_arn = aws_iam_policy.ssm[0].arn
 }
 
@@ -496,7 +498,7 @@ resource "aws_iam_policy" "eip" {
 resource "aws_iam_role_policy_attachment" "eip" {
   count = var.enable_eip ? 1 : 0
 
-  role       = aws_iam_role.instance.name
+  role       = var.runner_iam_role_name == ""  ? aws_iam_role.instance[0].name : var.runner_iam_role_name
   policy_arn = aws_iam_policy.eip[0].arn
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,22 +15,22 @@ output "runner_cache_bucket_name" {
 
 output "runner_agent_role_arn" {
   description = "ARN of the role used for the ec2 instance for the GitLab runner agent."
-  value       = aws_iam_role.instance.arn
+  value       = var.runner_iam_role_name == ""  ? aws_iam_role.instance[0].arn : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.runner_iam_role_name}"
 }
 
 output "runner_agent_role_name" {
   description = "Name of the role used for the ec2 instance for the GitLab runner agent."
-  value       = aws_iam_role.instance.name
+  value       = var.runner_iam_role_name == ""  ? aws_iam_role.instance[0].name : var.runner_iam_role_name
 }
 
 output "runner_role_arn" {
   description = "ARN of the role used for the docker machine runners."
-  value       = aws_iam_role.docker_machine.arn
+  value       = var.docker_machine_iam_role_name == ""  ? aws_iam_role.docker_machine[0].arn : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.docker_machine_iam_role_name}"
 }
 
 output "runner_role_name" {
   description = "Name of the role used for the docker machine runners."
-  value       = aws_iam_role.docker_machine.name
+  value       = var.docker_machine_iam_role_name == ""  ? aws_iam_role.docker_machine[0].name : var.docker_machine_iam_role_name
 }
 
 output "runner_agent_sg_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -742,6 +742,18 @@ variable "docker_machine_iam_policy_arns" {
   default     = []
 }
 
+variable "runner_iam_role_name" {
+  type        = string
+  description = "Policy/role to be added to the instance profile of the docker machine runners."
+  default     = ""
+}
+
+variable "docker_machine_iam_role_name" {
+  type        = string
+  description = "Policy/role to be added to the instance profile of the docker machine runners."
+  default     = ""
+}
+
 variable "sentry_dsn" {
   default     = "__SENTRY_DSN_REPLACED_BY_USER_DATA__"
   description = "Sentry DSN of the project for the runner to use (uses legacy DSN format)"


### PR DESCRIPTION
Adds support to terraform-aws-gitlab-runner to leverage prior existing roles; the goal here is to prevent orphaned references to the role the gitlab-runner module stands up if the runner stack is torn down, for example when performing cross account STS assumption.